### PR TITLE
Fixes rangy not to display error message on chrome >= 36

### DIFF
--- a/ant/build-lite-linux.ant
+++ b/ant/build-lite-linux.ant
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<project name="LoopIndex LITE Build and Deploy" basedir="..">
+
+ <!-- Load Environment specific properties from properties file -->
+	<property file="ant/local.properties" />
+	<property file="ant/build-lite.properties" />
+	
+	<taskdef resource="net/sf/antcontrib/antlib.xml"/>
+	
+<!--	<target name="compile-production-minimal-data" depends="init, update-air-version, set-release, set-network, touch-progress, base-compile, compile-air-runner, mix-xmls-only, build-air-installer" description="Compiles the network release version of the application, encoding only the main data files">
+		<echo message="Compiled network release version" />
+	</target>
+-->
+	
+<!-- Init with echoing some info to the console --> 
+	<target name="init" description="Initializes the build">
+		<tstamp/>
+		<property name="lite.version" value="${project.version}.${project.build}"/>
+		<echo message="======================================="/>
+		<echo message="lite version ${lite.version} [${TODAY}]"/>
+		<echo message="${project.name}-${project.version} [${TODAY}]"/>
+		<echo message="Copyright (c) ${project.year} ${project.owner}"/>
+		<echo message="OS : ${os.name}" />
+		<echo message="Author: ${author}" />
+		<echo message="Root: ${lite.dir}" />
+		<echo message="======================================="/>
+	 </target>
+	
+	<target name="set-version">
+	</target>
+	
+	<target name="clean">		
+	</target>
+	
+	<target name="zip-lite" depends="init" description="creates a distrbution zip">
+		<local name="rar.native"/>
+		<local name="rar.targetfile"/>
+		<local name="rar.target" />
+		<property name="rar.targetfile" value="${rar.targetfilePrefix}.${lite.version}.${rar.targetfileExtension}" />
+		<property name="rar.target" value="${lite.dir}/../${rar.targetfile}" />
+		
+		<script language="javascript">
+			project.setProperty('rar.native', project.getProperty('rar.target').
+			   replace(/\//g, "\\"));
+		</script>
+
+
+		<echo message="Deleting previous archive"/>
+		<exec executable="/bin/bash" dir="${lite.dir}">
+			<arg line="rm -rf ${rar.native}" />
+		</exec>
+		<echo message="running ${rar.exe}" />
+		<exec executable="${rar.exe}" dir="${lite.dir}">
+			<arg line="a" />
+			<arg line="-afzip" />
+			<arg line="${rar.target}" />
+			<arg line="demo" />
+			<arg line="docs" />
+			<arg line="src" />
+			<!-- arg line="lgpl.txt" / -->
+			<arg line="readme.md" />
+			<arg line="license.md" />
+			<arg line="readme.html" />
+			<arg line="license.html" />
+			<arg line="NOTICE" />
+		</exec>
+		
+		<echo message="Processing docs in archive" />
+		<exec executable="${rar.exe}" dir="${lite.dir}">
+			<arg line="d ${rar.target} src\lite\plugin.min.js docs\api\extjs docs\api\index.html" />
+		</exec>
+		<echo message="renaming index-ext.html to index.html" />
+		<exec executable="${rar.exe}" dir="${lite.dir}">
+			<arg line="rn ${rar.target} docs\api\index-ext.html docs\api\index.html" />
+		</exec>
+		
+		<echo message="Copying ${rar.native} to ${shared.dir}" />
+		<exec executable="/bin/bash" dir="${lite.dir}/..">
+			<arg line='cp -Rfvdp ${rar.targetfile} "${shared.dir}/${rar.targetfilePrefix}.${lite.version}._zip"' />
+      	</exec>
+	</target>
+	
+	<target name="zip-lite-dist" depends="init">
+		<local name="rar.native"/>
+		<local name="rar.targetfile"/>
+		<local name="rar.target" />
+		<property name="rar.targetBaseName" value="${rar.targetfilePrefix}.${lite.version}-dist" />
+		<property name="rar.targetfile" value="${rar.targetBaseName}.${rar.targetfileExtension}" />
+		<property name="rar.target" value="${lite.dir}/../${rar.targetfile}" />
+		
+		<script language="javascript">
+			project.setProperty('rar.native', project.getProperty('rar.target').
+			   replace(/\//g, "\\"));
+		</script>
+
+
+		<echo message="deleting previous version of ${rar.target}" />
+		<exec executable="/bin/bash" dir="${lite.dir}/..">
+			<arg line="rm -rf ${rar.targetfile}" />
+		</exec>
+		<echo message="running ${rar.exe}" />
+		
+		<exec executable="${rar.exe}" dir="${lite.dir}/src/dist">
+			<arg line="a" />
+			<arg line="${rar.target}" />
+			<arg line="lite" />
+		</exec>
+
+		<echo message="Copying ${rar.native} to ${shared.dir}" />
+		<exec executable="/bin/bash" dir="${lite.dir}/..">
+			<arg line='cp -Rfvdp ${rar.targetfile} "${shared.dir}/${rar.targetBaseName}._zip"' />
+      	</exec>
+	</target>
+
+	<macrodef name="minify-one" description="Minifies the file provided as a parameter">
+		<attribute name="src" />
+		<sequential>
+			<local name="srcdir" />
+			<local name="extension" />
+			<local name="basename" />
+			<local name="base" />
+			<local name="outputfile" />
+			<dirname file="@{src}" property="srcdir" />
+			<propertyregex property="extension" override="true" input="@{src}" regexp=".*\.([^\.]+)$" select="\1" />
+			<basename property="basename" file="@{src}" />
+			<propertyregex property="base" override="true" input="${basename}" regexp="(.*)\.([^\.]+)$" select="\1" />
+			<property name="outputfile" value="${base}.min.${extension}" />
+			<echo message="Calling minify @{src} ${base}.min.${extension} in directory ${srcdir}" />
+			<exec executable="yuicompressor" dir="${srcdir}" >
+				<arg line="-o ${outputfile}.tmp" />
+				<arg line="-v" />
+				<arg line="@{src}" />
+			</exec>
+			<echo message="concatenating text into ${srcdir}/${outputfile}" />
+			<concat destfile="${srcdir}/${outputfile}">
+				<header>/* Source version: ${project.version}.${project.build} */
+</header>
+				<footer>
+/* Copyright (C) 2015 LoopIndex - All Rights Reserved
+ * You may use, distribute and modify this code under the
+ * terms of the LoopIndex Comments CKEditor plugin license.
+ *
+ * You should have received a copy of the LoopIndex Comments CKEditor plugin license with
+ * this file. If not, please write to: loopindex@gmail.com, or visit http://www.loopindex.com
+ * written by (David *)Frenkiel (https://github.com/imdfl) 
+ */</footer>
+				<filelist dir="${srcdir}" files="${outputfile}.tmp" />
+			</concat>
+			<delete>
+				<fileset dir="${srcdir}">
+				    <include name="*.tmp"/>
+				</fileset>
+			</delete>
+		</sequential>
+	</macrodef>
+
+	<target name="minify-all" description="Minifies all the lite files">
+		<for param="file">
+			<path>
+				<fileset dir="${src.dir}">
+					<include name="lite*.js" />
+					<include name="plugin.js" />
+					<include name="js/opentip-adapter.js" />
+					<include name="**/*.css" />
+					<exclude name="**/*.min.*" />
+				</fileset>
+			</path>
+			<sequential>
+				<minify-one src="@{file}" />
+			</sequential>
+		</for>
+		<for param="file">
+			<path>
+				<fileset dir="${demo.dir}">
+					<include name="js/*.js" />
+					<exclude name="**/*.min.*" />
+				</fileset>
+			</path>
+			<sequential>
+				<minify-one src="@{file}" />
+			</sequential>
+		</for>
+	</target>
+	
+	<macrodef name="jsdoc">
+		<attribute name="src" />
+		<attribute name="target" />
+		<sequential>
+			<local name="srcdir" />
+			<local name="extension" />
+			<local name="basename" />
+			<local name="base" />
+			<local name="target.native" />
+			<local name="target.value" />
+			<local name="config.native" />
+			<property name="target.value" value="@{target}" />
+
+			<script language="javascript">
+				project.setProperty('target.native', project.getProperty('target.value').
+				   replace(/\//g, "\\"));
+				project.setProperty('config.native', project.getProperty('jsdoc.config').
+				   replace(/\//g, "\\"));
+			</script>
+
+			<echo message="deleting minified files" />
+			<exec executable="/bin/bash" dir="${src.dir}">
+				<arg line="rm *.min.js" />
+			</exec>
+
+			<echo message="removing output directory ${target.native}" />
+			<exec executable="/bin/bash">
+				<arg line="rm -rf ${target.native}" />
+			</exec>
+			
+			<echo message="Calling jsdoc @{src}, output generated in ${target.native}" />
+			<exec executable="${jsdoc.exe}" dir="${lite.dir}" >
+				<arg line="--output @{target}" />
+				<arg line="--config=${config.native}" />
+				<arg line="--ignore-global" />
+				<arg line="--verbose" />
+				<arg line="@{src}" />
+			</exec>
+		</sequential>
+	</macrodef>
+
+	<target name="build-docs" depends="init" description="Documents the Inquisitor project">
+		<jsdoc src="${docs.sources}" target="${docs.output.dir}" />
+		
+		<exec executable="/bin/bash" dir="${docs.output.dir}">
+			<arg line="/c" />
+			<arg line="copy index.html index-ext.html" />
+		</exec>
+
+		<replaceregexp file="${docs.output.dir}/index-ext.html" match="extjs/ext-all.js" replace="http://cdn.sencha.com/ext/gpl/4.2.0/ext-all.js"  />
+	
+	</target>
+
+	<target name="make-dist" depends="init">
+		<delete>
+			<fileset dir="${dist.dir}">
+			    <include name="**/*"/>
+			</fileset>
+		</delete>
+
+		<copy todir="${dist.dir}">
+			<fileset dir="${src.dir}">
+				<include name="icons/**" />
+				<include name="plugin.min.js" />
+				<include name="lite-interface.js" />
+				<include name="lite-includes.min.js" />
+				<include name="js/*.min.js" />
+				<include name="css/*.min.css" />
+				<include name="css/*.min.css" />
+				<include name="lang/*.js" />
+			</fileset>
+		</copy>
+
+		<copy todir="${dist.dir}">
+			<fileset dir="${lite.dir}">
+				<include name="readme.html" />
+				<include name="LICENSE.md" />
+			</fileset>
+		</copy>
+
+		<move file="${dist.dir}/plugin.min.js" tofile="${dist.dir}/plugin.js" overwrite="true"/>
+		<copy file="${dist.dir}/lite-includes.min.js" tofile="${dist.dir}/lite-includes.js" overwrite="true"/>
+		<move file="${dist.dir}/js/opentip-adapter.min.js" tofile="${dist.dir}/js/opentip-adapter.js" overwrite="true"/>
+		<move file="${dist.dir}/css/opentip.min.css" tofile="${dist.dir}/css/opentip.css" overwrite="true"/>
+		<move file="${dist.dir}/css/lite.min.css" tofile="${dist.dir}/css/lite.css" overwrite="true"/>
+	</target>
+	
+	<target name="build-version" depends="init,clean,set-version,minify-lite,minify-all,make-dist" />
+
+	<target name="minify-lite" description="Builds the include files for the LITE plugin" depends="init">
+		<property name="lite.includes" value="${src.dir}/lite-includes.js" />
+		<echo message="Concatenating LITE includes into ${lite.includes}" />
+		<concat destfile="${lite.includes}">
+			<filelist dir="${src.dir}/js" files="ns.js,rangy/rangy-core.js,ice.js,dom.js,selection.js,bookmark.js,../lite-interface.js" />
+		</concat>
+		<minify-one src="${lite.includes}" />
+	</target>
+
+</project>

--- a/src/lite/css/lite.css
+++ b/src/lite/css/lite.css
@@ -8,7 +8,7 @@ Written by (David *)Frenkiel - https://github.com/imdfl
 **/
 
 ins, del {
-	text-decoration: none !important;
+	/*text-decoration: none !important;*/
 }
 
 del.ice-del {
@@ -17,11 +17,11 @@ del.ice-del {
 
 ins.ice-ins, ins.ice-del {
 	white-space:pre-wrap;
-	text-decoration: none !important;
+	/*text-decoration: none !important;*/
 }
 
 ins.ice-no-decoration, del.ice-no-decoration {
-	text-decoration: none !important;
+	/*text-decoration: none !important;*/
 }
 
 .ICE-Tracking span.ice-ins, .ICE-Tracking ins.ice-ins,
@@ -34,19 +34,20 @@ ins.ice-no-decoration, del.ice-no-decoration {
 	display: inline;
 	text-decoration: line-through !important;
 	color: #555;
-	background-color: #e5ffcd !important;
+	/*background-color: #e5ffcd !important;*/
 }
 
 .ICE-Tracking .ice-ins, .ICE-Tracking .ice-ins>*  {
-	background-color: #e5ffcd !important;
+	/*background-color: #e5ffcd !important;*/
 }
 
 .ICE-Tracking .ice-ins.ice-cts-1, .ICE-Tracking .ice-ins.ice-cts-1>*  {
-	background-color: #e5ffcd !important;
+	/*background-color: #e5ffcd !important;*/
 }
 
 .ICE-Tracking .ice-ins.ice-cts-2, .ICE-Tracking .ice-ins.ice-cts-2>*  {
-	background-color: #e3ffff !important;
+	background-color: none !important;
+	color: #0000ff !important;
 }
 
 .ICE-Tracking .ice-ins.ice-cts-3, .ICE-Tracking .ice-ins.ice-cts-3>*  {
@@ -54,11 +55,12 @@ ins.ice-no-decoration, del.ice-no-decoration {
 }
 
 .ICE-Tracking .ice-del.ice-cts-1 {
-	background-color: #e5ffcd !important;
+	/*background-color: #e5ffcd !important;*/
 }
 
 .ICE-Tracking .ice-del.ice-cts-2 {
-	background-color: #e3ffff !important;
+	background-color: none !important;
+	color: #0000ff !important;
 }
 
 .ICE-Tracking .ice-del.ice-cts-3 {

--- a/src/lite/js/ice.js
+++ b/src/lite/js/ice.js
@@ -1485,7 +1485,8 @@
 					}
 				}
 				// Ignore empty space nodes
-				if (ice.dom.isEmptyTextNode(elem) || elem.getAttribute('data-cke-widget-wrapper') === '1') {
+				if (ice.dom.isEmptyTextNode(elem) 
+						|| elem.nodeType == ice.dom.ELEMENT_NODE && elem.getAttribute('data-cke-widget-wrapper') === '1') {
 					this._removeNode(elem);
 					continue;
 				}

--- a/src/lite/js/ice.js
+++ b/src/lite/js/ice.js
@@ -1485,7 +1485,7 @@
 					}
 				}
 				// Ignore empty space nodes
-				if (ice.dom.isEmptyTextNode(elem)) {
+				if (ice.dom.isEmptyTextNode(elem) || elem.getAttribute('data-cke-widget-wrapper') === '1') {
 					this._removeNode(elem);
 					continue;
 				}

--- a/src/lite/js/rangy/rangy-core.js
+++ b/src/lite/js/rangy/rangy-core.js
@@ -2874,38 +2874,48 @@
 				sel.removeAllRanges();
 	
 				// Test whether the native selection is capable of supporting multiple ranges
-					if (!selectionHasMultipleRanges) {
-				var r2 = r1.cloneRange();
-				r1.setStart(textNode, 0);
-						r2.setEnd(textNode, 3);
-						r2.setStart(textNode, 2);
-				sel.addRange(r1);
-	
-	                    // Next line causes Chrome 36 to print a console error of
-	                    // "Discontiguous selection is not supported.".
-	                    // https://code.google.com/p/chromium/issues/detail?id=353069#c4
-				sel.addRange(r2);
-	
-				selectionSupportsMultipleRanges = (sel.rangeCount == 2);
-						r2.detach();
-					}
-	
-				// Clean up
-					body.removeChild(testEl);
-					sel.removeAllRanges();
-	
-					for (i = 0; i < originalSelectionRangeCount; ++i) {
-						if (i == 0 && originalSelectionBackward) {
-							if (addRangeBackwardToNative) {
-								addRangeBackwardToNative(sel, originalSelectionRanges[i]);
-							} else {
-	                            api.warn("Rangy initialization: original selection was backwards but selection has been restored forwards because the browser does not support Selection.extend");
-	                            sel.addRange(originalSelectionRanges[i]);
-							}
-						} else {
-	                        sel.addRange(originalSelectionRanges[i]);
-						}
-					}
+				if (!selectionHasMultipleRanges) {
+                    // Doing the original feature test here in Chrome 36 (and presumably later versions) prints a
+                    // console error of "Discontiguous selection is not supported." that cannot be suppressed. There's
+                    // nothing we can do about this while retaining the feature test so we have to resort to a browser
+                    // sniff. I'm not happy about it. See
+                    // https://code.google.com/p/chromium/issues/detail?id=399791
+                    var chromeMatch = window.navigator.appVersion.match(/Chrome\/(.*?) /);
+                    if (chromeMatch && parseInt(chromeMatch[1]) >= 36) {
+                        selectionSupportsMultipleRanges = false;
+                    } else {
+        				var r2 = r1.cloneRange();
+        				r1.setStart(textNode, 0);
+    					r2.setEnd(textNode, 3);
+    					r2.setStart(textNode, 2);
+    			        sel.addRange(r1);
+
+                        // Next line causes Chrome 36 to print a console error of
+                        // "Discontiguous selection is not supported.".
+                        // https://code.google.com/p/chromium/issues/detail?id=353069#c4
+    			        sel.addRange(r2);
+
+        				selectionSupportsMultipleRanges = (sel.rangeCount == 2);
+    						r2.detach();
+    					}
+
+    				    // Clean up
+    					body.removeChild(testEl);
+    					sel.removeAllRanges();
+    	
+    					for (i = 0; i < originalSelectionRangeCount; ++i) {
+    						if (i == 0 && originalSelectionBackward) {
+    							if (addRangeBackwardToNative) {
+    								addRangeBackwardToNative(sel, originalSelectionRanges[i]);
+    							} else {
+    	                            api.warn("Rangy initialization: original selection was backwards but selection has been restored forwards because the browser does not support Selection.extend");
+    	                            sel.addRange(originalSelectionRanges[i]);
+    							}
+    						} else {
+    	                        sel.addRange(originalSelectionRanges[i]);
+    						}
+    					}
+                    }
 				}
 			})();
 		}

--- a/src/lite/lite-includes.js
+++ b/src/lite/lite-includes.js
@@ -2877,38 +2877,48 @@
 				sel.removeAllRanges();
 	
 				// Test whether the native selection is capable of supporting multiple ranges
-					if (!selectionHasMultipleRanges) {
-				var r2 = r1.cloneRange();
-				r1.setStart(textNode, 0);
-						r2.setEnd(textNode, 3);
-						r2.setStart(textNode, 2);
-				sel.addRange(r1);
-	
-	                    // Next line causes Chrome 36 to print a console error of
-	                    // "Discontiguous selection is not supported.".
-	                    // https://code.google.com/p/chromium/issues/detail?id=353069#c4
-				sel.addRange(r2);
-	
-				selectionSupportsMultipleRanges = (sel.rangeCount == 2);
-						r2.detach();
-					}
-	
-				// Clean up
-					body.removeChild(testEl);
-					sel.removeAllRanges();
-	
-					for (i = 0; i < originalSelectionRangeCount; ++i) {
-						if (i == 0 && originalSelectionBackward) {
-							if (addRangeBackwardToNative) {
-								addRangeBackwardToNative(sel, originalSelectionRanges[i]);
-							} else {
-	                            api.warn("Rangy initialization: original selection was backwards but selection has been restored forwards because the browser does not support Selection.extend");
-	                            sel.addRange(originalSelectionRanges[i]);
-							}
-						} else {
-	                        sel.addRange(originalSelectionRanges[i]);
-						}
-					}
+				if (!selectionHasMultipleRanges) {
+                    // Doing the original feature test here in Chrome 36 (and presumably later versions) prints a
+                    // console error of "Discontiguous selection is not supported." that cannot be suppressed. There's
+                    // nothing we can do about this while retaining the feature test so we have to resort to a browser
+                    // sniff. I'm not happy about it. See
+                    // https://code.google.com/p/chromium/issues/detail?id=399791
+                    var chromeMatch = window.navigator.appVersion.match(/Chrome\/(.*?) /);
+                    if (chromeMatch && parseInt(chromeMatch[1]) >= 36) {
+                        selectionSupportsMultipleRanges = false;
+                    } else {
+        				var r2 = r1.cloneRange();
+        				r1.setStart(textNode, 0);
+    					r2.setEnd(textNode, 3);
+    					r2.setStart(textNode, 2);
+    			        sel.addRange(r1);
+
+                        // Next line causes Chrome 36 to print a console error of
+                        // "Discontiguous selection is not supported.".
+                        // https://code.google.com/p/chromium/issues/detail?id=353069#c4
+    			        sel.addRange(r2);
+
+        				selectionSupportsMultipleRanges = (sel.rangeCount == 2);
+    						r2.detach();
+    					}
+
+    				    // Clean up
+    					body.removeChild(testEl);
+    					sel.removeAllRanges();
+    	
+    					for (i = 0; i < originalSelectionRangeCount; ++i) {
+    						if (i == 0 && originalSelectionBackward) {
+    							if (addRangeBackwardToNative) {
+    								addRangeBackwardToNative(sel, originalSelectionRanges[i]);
+    							} else {
+    	                            api.warn("Rangy initialization: original selection was backwards but selection has been restored forwards because the browser does not support Selection.extend");
+    	                            sel.addRange(originalSelectionRanges[i]);
+    							}
+    						} else {
+    	                        sel.addRange(originalSelectionRanges[i]);
+    						}
+    					}
+                    }
 				}
 			})();
 		}


### PR DESCRIPTION
The changed part is taken from latest rangy code as ckeditor-track-changes uses quite and old version of rangy

The idea of this patch is to get rid of "Discontiguous selection is not supported" on Chrome >= 36. The bug comes from rangy library which is a dependency of ckeditor-track-changes. ckeditor-track-changes uses quite old version of rangy while the latest version has some special case for this issue that doesn't throw the error but rather handles this situation quietly and just goes on.
