### PR TITLE
Update License to GPL2+

### DIFF
--- a/license.html
+++ b/license.html
@@ -9,7 +9,9 @@ DeLambo, see the LICENSE file in the ice folder.
 
 <h4>GPL</h4>
 
-This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License, version 2, as published by the Free Software Foundation.
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License 
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with this program as the file gpl.txt. 
 If not, see http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt


### PR DESCRIPTION
Since ICE has updatet his license terms to GPL2+  https://github.com/NYTimes/ice/pull/112/files 
it would be very appreciated if you could add this too. 

Thank you very much!