### PR TITLE
- Fixed error "ICE plugin init: TypeError: sel.nativeSelection is nul…

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -140,9 +140,8 @@ function f() {
 	function loadEditor(id, focus) {
 		
 		var state = editorStates[id];
-		if (state) {
-			$('#'+id).val("This editor was <strong>reloaded</strong>");
-		}
+        $('#' + id).val(state ? "This editor was <strong>reloaded</strong>" : "<p>Add or delete text to unleash the power of the <strong>Track Changes CKEditor Plugin</strong>.</p><p><ins class=\"ice-cts-1 ice-ins\" data-changedata=\"\" data-cid=\"2\" data-last-change-time=\"1502268617909\" data-time=\"1502268615033\" data-userid=\"18\" data-username=\"Roger\">This is Roger</ins></p>");
+
 		
 		var editor = CKEDITOR.replace( id , { 
 			height: "400" ,

--- a/src/lite/js/ice.js
+++ b/src/lite/js/ice.js
@@ -1527,7 +1527,7 @@
 					var parentBlock = ice.dom.getBlockParent(elem);
 					this._addDeleteTracking(elem, addDeleteOptions);
 					if (ice.dom.hasNoTextOrStubContent(parentBlock)) {
-						ice.dom.remove(parentBlock);
+					    this._removeNode(parentBlock);
 					}
 				}
 			}

--- a/src/lite/js/rangy-core.js
+++ b/src/lite/js/rangy-core.js
@@ -3427,8 +3427,8 @@
                 if (implementsControlRange && implementsDocSelection && sel.docSelection.type == CONTROL) {
                     updateControlSelection(sel);
                 } else {
-                    sel._ranges.length = sel.rangeCount = sel.nativeSelection.rangeCount;
-                    if (sel.rangeCount) {
+                    if (sel.nativeSelection && sel.nativeSelection.rangeCount) {
+                        sel._ranges.length = sel.rangeCount = sel.nativeSelection.rangeCount;
                         for (var i = 0, len = sel.rangeCount; i < len; ++i) {
                             sel._ranges[i] = new api.WrappedRange(sel.nativeSelection.getRangeAt(i));
                         }


### PR DESCRIPTION
- Fixed error "ICE plugin init: TypeError: sel.nativeSelection is null" on loading CKEditor
- Reworked demo.js to initially set ckeditor data to value which helps to reproduce the bug "'ice.dom.remove is not a function' error occurs when clicking on 1. Ctrl+A, 2. Del buttons on ckeditor control"
- Fixed 'ice.dom.remove is not a function' error when clicking on 1. Ctrl+A, 2. Del buttons on ckeditor control