### PR TITLE
Minor syntax error corrected

### DIFF
--- a/src/lite/plugin.js
+++ b/src/lite/plugin.js
@@ -152,7 +152,7 @@ Written by (David *)Frenkiel - https://github.com/imdfl
 	isOldCKEDITOR = false;
 
 	function isLITENode(node) {
-		return node && node.className && IS_LITE_CLASS_RE(node.className);
+		return node && node.className && IS_LITE_CLASS_RE.test(node.className);
 	}
 
 	


### PR DESCRIPTION
Regex used as a function directly instead of using the .test() function.
This bug was causing trouble when copy/pasting some tables.